### PR TITLE
Copy go.sum to ensure deps are resolved properly

### DIFF
--- a/compression-workflows/Dockerfile
+++ b/compression-workflows/Dockerfile
@@ -5,7 +5,7 @@ FROM golang:1.23 AS build
 WORKDIR /app
 
 # Download Go modules
-COPY container/go.mod ./
+COPY container/go.mod container/go.sum ./
 RUN go mod download
 
 # Copy container src

--- a/http2/Dockerfile
+++ b/http2/Dockerfile
@@ -5,7 +5,7 @@ FROM golang:1.24 AS build
 WORKDIR /app
 
 # Download Go modules
-COPY container/go.mod ./
+COPY container/go.mod container/go.sum ./
 RUN go mod download
 
 # Copy container src


### PR DESCRIPTION
Currently, for the demos where external modules are used, running `pnpm run deploy` throws the following error:
```
❯ pnpm run deploy

> http2@0.0.0 deploy /home/ghost_000/github/cloudflare/containers-demos/http2
> wrangler deploy


 ⛅️ wrangler 0.0.0-v0df039b7e
-----------------------------

Total Upload: 1.10 KiB / gzip: 0.55 KiB
Your worker has access to the following bindings:
- Durable Objects:
  - CONTAINER: Container
Uploaded http2 (4.52 sec)
Deployed http2 triggers (2.64 sec)
  https://http2.ghostwriternr.workers.dev
Building image http2:237b7490
[+] Building 1.7s (14/15)                                                                                                                                        docker:default
 => [internal] load build definition from Dockerfile                                                                                                                       0.0s
 => => transferring dockerfile: 460B                                                                                                                                       0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1                                                                                                  0.6s
 => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:4c68376a702446fc3c79af22de146a148bc3367e73c25a5803d453b6b3f722fb                                            0.0s
 => [internal] load metadata for docker.io/library/debian:latest                                                                                                           0.4s
 => [internal] load metadata for docker.io/library/golang:1.24                                                                                                             0.5s
 => [internal] load .dockerignore                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                            0.0s
 => [build 1/6] FROM docker.io/library/golang:1.24@sha256:1ecc479bc712a6bdb56df3e346e33edcc141f469f82840bab9f4bc2bc41bf91d                                                 0.0s
 => CACHED [stage-1 1/2] FROM docker.io/library/debian:latest@sha256:00cd074b40c4d99ff0c24540bdde0533ca3791edcdac0de36d6b9fb3260d89e2                                      0.0s
 => [internal] load build context                                                                                                                                          0.0s
 => => transferring context: 1.67kB                                                                                                                                        0.0s
 => CACHED [build 2/6] WORKDIR /app                                                                                                                                        0.0s
 => CACHED [build 3/6] COPY container/go.mod ./                                                                                                                            0.0s
 => CACHED [build 4/6] RUN go mod download                                                                                                                                 0.0s
 => [build 5/6] COPY container/*.go ./                                                                                                                                     0.0s
 => ERROR [build 6/6] RUN CGO_ENABLED=0 GOOS=linux go build -o /server                                                                                                     0.2s
------                                                                                                                                                                          
 > [build 6/6] RUN CGO_ENABLED=0 GOOS=linux go build -o /server:                                                                                                                
0.196 main.go:12:2: missing go.sum entry for module providing package golang.org/x/net/http2 (imported by server); to add:                                                      
0.196 	go get server                                                                                                                                                           
0.196 main.go:13:2: missing go.sum entry for module providing package golang.org/x/net/http2/h2c (imported by server); to add:
0.196 	go get server
------
Dockerfile:14
--------------------
  12 |     COPY container/*.go ./
  13 |     # Build
  14 | >>> RUN CGO_ENABLED=0 GOOS=linux go build -o /server
  15 |     
  16 |     FROM debian:latest
--------------------
ERROR: failed to solve: process "/bin/sh -c CGO_ENABLED=0 GOOS=linux go build -o /server" did not complete successfully: exit code: 1
╰  ERROR  Build exited with code: 1
 ELIFECYCLE  Command failed with exit code 1.
```

Copying over the `go.sum` file along with `go.mod` in the Dockerfile resolves this.