### PR TITLE
CC-5742: enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '**/*'
+    versioning-strategy: increase
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Iirc this is all we need to do. This will have dependabot run weekly to update the all of the dependencies in this repository (can probably make it just update wrangler though if that'd be better).

Note this will open PRs that will update the dependencies, we still need to merge them manually.